### PR TITLE
WTEL-9448: Default sort by created_at DESC

### DIFF
--- a/model/media_file.go
+++ b/model/media_file.go
@@ -16,7 +16,7 @@ type SearchMediaFile struct {
 }
 
 func (MediaFile) DefaultOrder() string {
-	return "id"
+	return "-created_at"
 }
 
 func (a MediaFile) AllowFields() []string {


### PR DESCRIPTION
## Зміни
Оновлено `MediaFile.DefaultOrder()` з `id` на `-created_at`.
