### PR TITLE
feat: move cert/dir setup to postinst drop-in hook

### DIFF
--- a/deploy/debian/postinst.d/10-storage.sh
+++ b/deploy/debian/postinst.d/10-storage.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Storage-specific postinst setup.
+#
+# Run by the generic Debian postinst (webitel/reusable-configs) BEFORE any
+# unit is started — it is sourced under `set -e`, so a failure here aborts
+# the install (correct: the service cannot run without its signing key).
+#
+# Creates the storage working directories and the presigned-URL signing key.
+
+# Create the directories only when missing, so we never change the ownership
+# of an existing deployment's data/recordings on upgrade.
+for dir in /opt/storage /opt/storage/data /opt/storage/recordings; do
+    [ -d "$dir" ] || install -d -o webitel -g webitel -m 0750 "$dir"
+done
+
+KEY=/opt/storage/key.pem
+if [ ! -f "$KEY" ]; then
+    echo "Generating storage signing key: $KEY"
+    openssl genrsa -out "$KEY" 2048
+    chown webitel:webitel "$KEY"
+    chmod 600 "$KEY"
+fi


### PR DESCRIPTION
## What

Moves storage's working-dir and signing-key setup out of `preinst` into a drop-in hook run by the centralized generic `postinst` (see webitel/reusable-configs).

Adds `deploy/debian/postinst.d/10-storage.sh`, which the generic postinst sources **before** the unit is started:
- creates `/opt/storage/{,data,recordings}` only when missing (never re-chowns an existing deployment);
- generates `/opt/storage/key.pem` when absent — now `openssl genrsa 2048` (was 512), owned `webitel:webitel`, mode `0600`.

The matching `package-contents` entry (`src=deploy/debian/postinst.d/ dst=/usr/lib/webitel-storage/deb/postinst.d/`) is added in the reusable-configs PR.

## Order
Merge this **before** storage's sync PR lands, otherwise the regenerated workflow references a `postinst.d/` that doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)