### PR TITLE
chore: add .env.example and fix unit binary path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,65 @@
+CONSUL=127.0.0.1:8500
+MESSAGE_BROKER_URL=amqp://admin:admin@rabbit:5672?heartbeat=10
+DATA_SOURCE=postgres://postgres:postgres@postgres:5432/webitel?application_name=storage&sslmode=disable&connect_timeout=10
+
+PUBLIC_HOST=https://example.org
+GRPC_ADDR=127.0.0.1
+
+PRESIGNED_CERT=/opt/storage/key.pem
+MEDIA_DIRECTORY=/opt/storage/data
+TEMP_DIRECTORY=/var/lib/webitel/storage-temp
+
+# ID=1
+# DEV=false
+# TRANSLATION_DIRECTORY=/usr/share/webitel/storage/i18n
+
+# PUBLIC_ADDRESS=:10023
+# INTERNAL_ADDRESS=:10021
+# gRPC port (0 = random)
+# GRPC_PORT=0
+# GRPC_NETWORK=tcp
+
+# MESSAGE_BROKER_EXCHANGE=cases
+# TRIGGER_ENABLED=1
+
+# SQL_DRIVER_NAME=postgres
+# SQL_DATA_SOURCE_REPLICAS=
+# SQL_MAX_IDLE_CONNS=5
+# SQL_MAX_OPEN_CONNS=5
+# SQL_LIFETIME_MILLISECONDS=300000
+# SQL_TRACE=false
+# SQL_LOG=false
+# QUERY_TIMEOUT=10
+
+# PRESIGNED_TIMEOUT=900000
+# CRYPTO_KEY=
+
+# Templated by storage at runtime ($DOMAIN/$Y/$M/$D/$H)
+# MEDIA_STORE_PATTERN=$DOMAIN
+# MAX_UPLOAD_FILE_SIZE=20MB
+# FILE_STORE_TYPE=
+# File expire day (0 = never delete)
+# FILE_STORE_EXPIRE_DAY=0
+# FILE_STORE_PROPS="{\"directory\": \"/opt/storage/recordings\", \"path_pattern\": \"$DOMAIN/$Y/$M/$D/$H\"}"
+# PROXY_UPLOAD=
+# SAFE_UPLOAD_MAX_SLEEP=60sec
+# WATCHERS_ENABLED=1
+
+# CLAM_ADDRESS=
+# Clam mode: aggressive | quarantine | skip
+# CLAM_MODE=quarantine
+
+# THUMBNAIL_FORCE_ENABLE=0
+# THUMBNAIL_DEFAULT_SCALE=
+
+# WBT_TTS_ENDPOINT=
+
+# LOGGER_ENABLED=1
+# LOG_LVL=debug
+# LOG_JSON=false
+# LOG_OTEL=false
+# LOG_CONSOLE=false
+# LOG_FILE=
+
+# Path to Google Cloud service-account JSON (only for GCS file store)
+# GOOGLE_APPLICATION_CREDENTIALS=/opt/webitel/application_default_credentials.json

--- a/deploy/systemd/webitel-storage.service
+++ b/deploy/systemd/webitel-storage.service
@@ -8,7 +8,7 @@ Restart=always
 LimitNOFILE=65536
 TimeoutStartSec=0
 Environment="GOOGLE_APPLICATION_CREDENTIALS=/opt/webitel/application_default_credentials.json"
-ExecStart=/usr/local/bin/storage \
+ExecStart=/usr/local/bin/webitel-storage \
     -translations_directory /usr/share/webitel/storage/i18n \
     -consul 127.0.0.1:8500 \
     -grpc_addr 127.0.0.1 \


### PR DESCRIPTION
Adds a documented `.env.example` (env names from `model/config.go`; required vars uncommented, optional commented with defaults).

Also fixes the systemd unit ExecStart binary path: `/usr/local/bin/storage` -> `/usr/local/bin/webitel-storage` (matches the packaged binary name).

Note: not wired into package-contents / EnvironmentFile yet — that comes with the env migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)