### PR TITLE
feat(deb): create i18n dir in postinst

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ TEMP_DIRECTORY=/var/lib/webitel/storage-temp
 
 # ID=1
 # DEV=false
-# TRANSLATION_DIRECTORY=/usr/share/webitel/storage/i18n
+TRANSLATION_DIRECTORY=/usr/share/webitel/storage/i18n
 
 # PUBLIC_ADDRESS=:10023
 # INTERNAL_ADDRESS=:10021

--- a/deploy/debian/postinst.d/10-storage.sh
+++ b/deploy/debian/postinst.d/10-storage.sh
@@ -14,6 +14,9 @@ for dir in /opt/storage /opt/storage/data /opt/storage/recordings; do
     [ -d "$dir" ] || install -d -o webitel -g webitel -m 0750 "$dir"
 done
 
+I18N_DIR=/usr/share/webitel/storage/i18n
+[ -d "$I18N_DIR" ] || install -d -o webitel -g webitel -m 0755 "$I18N_DIR"
+
 KEY=/opt/storage/key.pem
 if [ ! -f "$KEY" ]; then
     echo "Generating storage signing key: $KEY"


### PR DESCRIPTION
Create the translations directory (`/usr/share/webitel/<svc>/i18n`) via a postinst `install -d` hook (create-if-missing) and point `TRANSLATION_DIRECTORY` at it — the service refuses to start without the directory.

Directories are created at install time (not via systemd-tmpfiles): no per-boot re-touch, no cleanup-timer risk to data dirs.

> Note: package build stays red until the matching reusable-configs `sync.yml` change (ship `postinst.d/`) is merged and re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)