### PR TITLE
ref(systemd): use CacheDirectory for temp, single RW root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ GRPC_ADDR=127.0.0.1
 
 PRESIGNED_CERT=/opt/storage/key.pem
 MEDIA_DIRECTORY=/opt/storage/data
-TEMP_DIRECTORY=/var/lib/webitel/storage-temp
+TEMP_DIRECTORY=/var/cache/webitel-storage
 
 # ID=1
 # DEV=false

--- a/deploy/systemd/webitel-storage.service
+++ b/deploy/systemd/webitel-storage.service
@@ -9,6 +9,7 @@ Type=simple
 User=webitel
 Group=webitel
 LogsDirectory=webitel
+CacheDirectory=webitel-storage
 
 EnvironmentFile=/etc/default/webitel-storage
 EnvironmentFile=-/etc/default/webitel-otel
@@ -36,8 +37,6 @@ NoExecPaths=/
 ExecPaths=/usr/local/bin/webitel-storage
 ExecPaths=/usr/bin/ffmpeg
 ReadWritePaths=/opt/storage
-ReadWritePaths=/opt/recordings
-ReadWritePaths=/var/lib/webitel/storage-temp
 
 # Process isolation
 PrivateDevices=yes


### PR DESCRIPTION
Reconcile storage directories so unit / env / postinst hook agree:

- **temp** → systemd `CacheDirectory=webitel-storage` (`/var/cache/webitel-storage`); `TEMP_DIRECTORY` points there. The old `/var/lib/webitel/storage-temp` was never created by the hook.
- **recordings/media/key** all live under `/opt/storage`, so a single `ReadWritePaths=/opt/storage` covers them; drop the stray `/opt/recordings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)