### PR TITLE
fix(buf): track protos main branch on main

### DIFF
--- a/buf/buf.gen.engine.yaml
+++ b/buf/buf.gen.engine.yaml
@@ -15,7 +15,7 @@ plugins:
 inputs:
 #  - directory: "../protos/engine"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: engine
     types:
       - engine.Lookup

--- a/buf/buf.gen.yaml
+++ b/buf/buf.gen.yaml
@@ -22,5 +22,5 @@ plugins:
 inputs:
 #  - directory: "../protos/storage"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: storage


### PR DESCRIPTION
## What
Point the drifted `buf` proto inputs back at `github.com/webitel/protos` **main** on the `main` branch (they were pinned to a release branch).

## Why
On `main`, buf must track protos `main`; pinning to a release branch belongs only on release branches.

## Note
Config-only change; no generated code is regenerated here.