### PR TITLE
fix(env): set required file store defaults in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,10 @@ TRANSLATION_DIRECTORY=/usr/share/webitel/storage/i18n
 # Templated by storage at runtime ($DOMAIN/$Y/$M/$D/$H)
 # MEDIA_STORE_PATTERN=$DOMAIN
 # MAX_UPLOAD_FILE_SIZE=20MB
-# FILE_STORE_TYPE=
+FILE_STORE_TYPE=local
 # File expire day (0 = never delete)
-# FILE_STORE_EXPIRE_DAY=0
-# FILE_STORE_PROPS="{\"directory\": \"/opt/storage/recordings\", \"path_pattern\": \"$DOMAIN/$Y/$M/$D/$H\"}"
+FILE_STORE_EXPIRE_DAY=0
+FILE_STORE_PROPS="{\"directory\": \"/opt/storage/recordings\", \"path_pattern\": \"$DOMAIN/$Y/$M/$D/$H\"}"
 # PROXY_UPLOAD=
 # SAFE_UPLOAD_MAX_SLEEP=60sec
 


### PR DESCRIPTION
## What
Uncomment the file-store settings in `.env.example` so a fresh deploy starts without manual edits (values taken from the legacy systemd unit):

```
FILE_STORE_TYPE=local
FILE_STORE_EXPIRE_DAY=0
FILE_STORE_PROPS="{\"directory\": \"/opt/storage/recordings\", \"path_pattern\": \"$DOMAIN/$Y/$M/$D/$H\"}"
```

## Why
`FILE_STORE_TYPE` / `FILE_STORE_PROPS` have no code default (`flag:"file_store_type||…"`), so with them commented out the service has no configured file store and cannot operate. The old `deployment/webitel/etc/systemd/system/storage.service` set these as working defaults; this restores them in the template.